### PR TITLE
add rlike keyword and formatting

### DIFF
--- a/moz_sql_parser/formatting.py
+++ b/moz_sql_parser/formatting.py
@@ -241,6 +241,12 @@ class Formatter:
     def _not_like(self, pair):
         return "{0} NOT LIKE {1}".format(self.dispatch(pair[0]), self.dispatch(pair[1]))
 
+    def _rlike(self, pair):
+        return "{0} RLIKE {1}".format(self.dispatch(pair[0]), self.dispatch(pair[1]))
+
+    def _not_rlike(self, pair):
+        return "{0} NOT RLIKE {1}".format(self.dispatch(pair[0]), self.dispatch(pair[1]))
+
     def _is(self, pair):
         return "{0} IS {1}".format(self.dispatch(pair[0]), self.dispatch(pair[1]))
 

--- a/moz_sql_parser/keywords.py
+++ b/moz_sql_parser/keywords.py
@@ -36,6 +36,7 @@ OUTER = Keyword("outer", caseless=True)
 OVER = Keyword("over", caseless=True).suppress()
 PARTITION = Keyword("partition", caseless=True).suppress()
 RIGHT = Keyword("right", caseless=True)
+RLIKE = Keyword("rlike", caseless=True)
 SELECT = Keyword("select", caseless=True).suppress()
 THEN = Keyword("then", caseless=True).suppress()
 UNION = Keyword("union", caseless=True)
@@ -91,6 +92,7 @@ UNION_ALL = Group(UNION + ALL).set_parser_name("union_all")
 # COMPOUND OPERATORS
 NOT_BETWEEN = Group(NOT + BETWEEN).set_parser_name("not_between")
 NOT_LIKE = Group(NOT + LIKE).set_parser_name("not_like")
+NOT_RLIKE = Group(NOT + RLIKE).set_parser_name("not_rlike")
 NOT_IN = Group(NOT + IN).set_parser_name("nin")
 IS_NOT = Group(IS + NOT).set_parser_name("is_not")
 
@@ -139,6 +141,7 @@ binary_ops = {
     "is not": "neq",
     "is": "eq",
     "not like": "not_like",
+    "not rlike": "not_rlike",
     "or": "or",
     "and": "and",
 }
@@ -169,6 +172,8 @@ precedence = {
     "is": 8,
     "like": 8,
     "not_like": 8,
+    "rlike": 8,
+    "not_rlike": 8,
     "and": 10,
     "or": 11,
 }
@@ -193,6 +198,8 @@ KNOWN_OPS = [
     IS,
     LIKE,
     NOT_LIKE,
+    RLIKE,
+    NOT_RLIKE,
     NOT,
     AND,
     OR,

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -232,6 +232,29 @@ class TestSimple(TestCase):
         )
         self.assertEqual(result, expected)
 
+    def test_rlike_in_where(self):
+        result = format({
+            "from": "table1",
+            "where": {"rlike": ["A", {"literal": ".*20.*"}]},
+            "select": {"value": "a"},
+        })
+        expected = "SELECT a FROM table1 WHERE A RLIKE '.*20.*'"
+        self.assertEqual(result, expected)
+
+    def test_rlike_in_select(self):
+        result = format({
+            "from": "table1",
+            "select": {
+                "name": "bb",
+                "value": {"case": [
+                    {"when": {"rlike": ["A", {"literal": "bb.*"}]}, "then": 1},
+                    0,
+                ]},
+            },
+        })
+        expected = "SELECT CASE WHEN A RLIKE 'bb.*' THEN 1 ELSE 0 END AS bb FROM table1"
+        self.assertEqual(result, expected)
+
     def test_in_expression(self):
         result = format({
             "from": "task",

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -305,6 +305,59 @@ class TestSimple(TestCase):
         }
         self.assertEqual(result, expected)
 
+
+    def test_rlike_in_where(self):
+        result = parse("select a from table1 where A rlike '.*20.*'")
+        expected = {
+            "from": "table1",
+            "where": {"rlike": ["A", {"literal": ".*20.*"}]},
+            "select": {"value": "a"},
+        }
+        self.assertEqual(result, expected)
+
+    def test_not_rlike_in_where(self):
+        result = parse("select a from table1 where A not rlike '.*20.*'")
+        expected = {
+            "from": "table1",
+            "where": {"not_rlike": ["A", {"literal": ".*20.*"}]},
+            "select": {"value": "a"},
+        }
+        self.assertEqual(result, expected)
+
+    def test_rlike_in_select(self):
+        #               0         1         2         3         4         5         6
+        #               0123456789012345678901234567890123456789012345678901234567890123456789
+        result = parse(
+            "select case when A rlike 'bb.*' then 1 else 0 end as bb from table1"
+        )
+        expected = {
+            "from": "table1",
+            "select": {
+                "name": "bb",
+                "value": {"case": [
+                    {"when": {"rlike": ["A", {"literal": "bb.*"}]}, "then": 1},
+                    0,
+                ]},
+            },
+        }
+        self.assertEqual(result, expected)
+
+    def test_not_rlike_in_select(self):
+        result = parse(
+            "select case when A not rlike 'bb.*' then 1 else 0 end as bb from table1"
+        )
+        expected = {
+            "from": "table1",
+            "select": {
+                "name": "bb",
+                "value": {"case": [
+                    {"when": {"not_rlike": ["A", {"literal": "bb.*"}]}, "then": 1},
+                    0,
+                ]},
+            },
+        }
+        self.assertEqual(result, expected)
+
     def test_in_expression(self):
         result = parse(
             "select * from task where repo.branch.name in ('try', 'mozilla-central')"


### PR DESCRIPTION
Hi, is it possible to add the rlike keyword? 

rlike is part of a series of regex-related keywords, implemented by mysql where it is syntactically the same as like.

There are other engines that implement rlike as a function (ie snowflake) though this PR only covers the mysql syntax.